### PR TITLE
rename from exo to imua

### DIFF
--- a/genesis/imuachaintestnet_233-8.json
+++ b/genesis/imuachaintestnet_233-8.json
@@ -37,8 +37,8 @@
           "imua_chain_index": "0",
           "finalization_blocks": "10",
           "layer_zero_chain_id": "0",
-          "meta_info": "The (native) Exocore chain",
-          "name": "Exocore",
+          "meta_info": "The (native) Imuachain",
+          "name": "Imuachain",
           "signature_type": ""
         },
         {
@@ -79,8 +79,8 @@
             "decimals": 18,
             "imua_chain_index": "1",
             "layer_zero_chain_id": "0",
-            "meta_info": "EXO native to the Exocore chain",
-            "name": "Native EXO token",
+            "meta_info": "IMUA native to Imuachain",
+            "name": "Native IMUA token",
             "symbol": "IMUA"
           },
           "staking_total_amount": "0"
@@ -91,7 +91,7 @@
             "decimals": 18,
             "imua_chain_index": "0",
             "layer_zero_chain_id": "40217",
-            "meta_info": "Exocore Holesky ETH",
+            "meta_info": "Imuachain Holesky LST ETH",
             "name": "exo ETH",
             "symbol": "exoETH"
           },
@@ -103,7 +103,7 @@
             "decimals": 18,
             "imua_chain_index": "0",
             "layer_zero_chain_id": "40161",
-            "meta_info": "Exocore testnet ETH",
+            "meta_info": "Imuachain Sepolia LST ETH",
             "name": "exoETH",
             "symbol": "exoETH"
           },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated blockchain metadata to reflect a fresh rebranding. The native chain name and corresponding token labels have been changed from the previous branding to the new Imuachain identifiers, ensuring clearer and more consistent information across the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->